### PR TITLE
fix: option can not be an empty string

### DIFF
--- a/src/client/components/DynamicParameter.tsx
+++ b/src/client/components/DynamicParameter.tsx
@@ -380,8 +380,8 @@ const ParameterField: FC<ParameterFieldProps> = ({
 		case "dropdown":
 			return (
 				<Select
-					onValueChange={onChange}
-					value={value}
+					onValueChange={(v) => onChange(v.substring(5))}
+					value={`data-${value}`}
 					disabled={disabled}
 					required={parameter.required}
 				>
@@ -392,7 +392,10 @@ const ParameterField: FC<ParameterFieldProps> = ({
 					</SelectTrigger>
 					<SelectContent>
 						{parameter.options.map((option) => (
-							<SelectItem key={option.value.value} value={option.value.value || "??"}>
+							<SelectItem
+								key={option.value.value}
+								value={`data-${option.value.value}`}
+							>
 								<OptionDisplay option={option} />
 							</SelectItem>
 						))}
@@ -487,9 +490,11 @@ const ParameterField: FC<ParameterFieldProps> = ({
 		case "radio":
 			return (
 				<RadioGroup
-					onValueChange={onChange}
+					onValueChange={(v) => {
+						onChange(v.substring(5));
+					}}
 					disabled={disabled}
-					value={value}
+					value={`data-${value}`}
 					className="relative"
 				>
 					{parameter.options.map((option) => (
@@ -499,7 +504,7 @@ const ParameterField: FC<ParameterFieldProps> = ({
 						>
 							<RadioGroupItem
 								id={`${id}-${option.value.value}`}
-								value={option.value.value || "??"}
+								value={`data-${option.value.value}`}
 							/>
 							<Label
 								htmlFor={`${id}-${option.value.value}`}

--- a/src/client/components/DynamicParameter.tsx
+++ b/src/client/components/DynamicParameter.tsx
@@ -392,7 +392,7 @@ const ParameterField: FC<ParameterFieldProps> = ({
 					</SelectTrigger>
 					<SelectContent>
 						{parameter.options.map((option) => (
-							<SelectItem key={option.value.value} value={option.value.value}>
+							<SelectItem key={option.value.value} value={option.value.value || "??"}>
 								<OptionDisplay option={option} />
 							</SelectItem>
 						))}
@@ -499,7 +499,7 @@ const ParameterField: FC<ParameterFieldProps> = ({
 						>
 							<RadioGroupItem
 								id={`${id}-${option.value.value}`}
-								value={option.value.value}
+								value={option.value.value || "??"}
 							/>
 							<Label
 								htmlFor={`${id}-${option.value.value}`}


### PR DESCRIPTION
Radix components that take an `value` of type `string` break when the value is `""`.

![CleanShot 2025-06-13 at 10 59 03](https://github.com/user-attachments/assets/96908896-c91d-4deb-b410-cc3d5f97a8e3)

A hack but It could be better to make the value something descriptive as a pseudo error message